### PR TITLE
Add option to log VOPM .OPM files when converting OPN to YM2413

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -124,6 +124,15 @@ const sections = [
     ]
   },
   {
+    header: "OPN (YM2203/YM2608/YM2612) to YM2413 OPTIONS",
+    content: [
+      {
+        def: "{bold -D} opmOutput={underline filename}",
+        desc: "Output VOPM voice file. VOPM voices are only logged if this is included."
+      },
+    ]
+  },
+  {
     header: "YM2612 to YM2413 OPTIONS",
     content: [
       {
@@ -220,6 +229,7 @@ const defineKeyTypeMap: { [key: string]: any } = {
   "dacEmulation": ["fmpcm", "test", "none"],
   "mixResolver": ["tone", "noise", "mix"],
   "mixChannel": Number,
+  "opmOutput": String,
   "periodicNoiseAssignment": ["tone", "noise", "mix", "env.tri", "env.saw", "none"],
   "periodicNoisePitchShift": Number,
   "periodicNoiseAttenuation": Number,

--- a/src/converter/opn-to-ym2413-converter.ts
+++ b/src/converter/opn-to-ym2413-converter.ts
@@ -2,6 +2,7 @@ import { VGMConverter, ChipInfo } from "./vgm-converter";
 import { VGMCommand, VGMEndCommand, VGMWriteDataCommand } from "vgm-parser";
 import VGMWriteDataCommandBuffer from "./vgm-write-data-buffer";
 import { OPNVoice } from "ym-voice";
+import { writeOpmVoiceData } from "../opm";
 
 type VoiceMapEntry = {
   i: number;
@@ -389,6 +390,9 @@ export abstract class OPNToYM2413Converter extends VGMConverter {
         const vdef = this._voiceDefMap[hash];
         console.error(`/*${opnVoice.toMML("mucom88")}*/`);
         console.error(`"${hash}":${_voiceMapEntryString(vdef)}, // Used in CH:${Array.from(channels)}`);
+      }
+      if (this.opts.opmOutput) {
+        writeOpmVoiceData(this.opts.opmOutput, Object.values(this._voiceInfoMap));
       }
       return [cmd];
     }

--- a/src/opm.ts
+++ b/src/opm.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { OPNVoice, OPNSlotParam } from "ym-voice";
 
-const OPM_HEADER = "//VOPM tone data\n//Ripped by vgm-conv\n\n";
+const OPM_HEADER = "//VOPM tone data\n//Ripped by vgm-conv\n";
 
 function pad4(value: number) {
   return `${value}`.padStart(4, " ");
@@ -21,7 +21,6 @@ M1:${convertSlot(voice.slots[0])}   0   ${pad4(voice.slots[0].am)}
 C1:${convertSlot(voice.slots[1])}   0   ${pad4(voice.slots[0].am)}
 M2:${convertSlot(voice.slots[2])}   0   ${pad4(voice.slots[0].am)}
 C2:${convertSlot(voice.slots[3])}   0   ${pad4(voice.slots[0].am)}
-
 `;
 }
 
@@ -30,7 +29,7 @@ export function writeOpmVoiceData(filename: string, voices: { opnVoice: OPNVoice
   opmOutput += OPM_HEADER;
 
   voices.forEach((voice, index) => {
-    opmOutput += toVOPM(voice.opnVoice, index, Array.from(voice.channels).join(","));
+    opmOutput += "\n" + toVOPM(voice.opnVoice, index, Array.from(voice.channels).join(","));
   });
 
   fs.writeFileSync(filename, opmOutput);

--- a/src/opm.ts
+++ b/src/opm.ts
@@ -3,33 +3,13 @@ import { OPNVoice, OPNSlotParam } from "ym-voice";
 
 const OPM_HEADER = "//VOPM tone data\n//Ripped by vgm-conv\n";
 
-function pad4(value: number) {
-  return `${value}`.padStart(4, " ");
-}
-
-function toVOPM(voice: OPNVoice, id: number = 0, channels: string = "") {
-  function convertSlot(slot: OPNSlotParam) {
-    return [slot.ar, slot.dr, slot.sr, slot.rr, slot.sl, slot.tl, slot.ks, slot.ml, slot.dt].map(pad4).join("");
-  }
-  return `@:${id} CH${channels}
-//  LFRQ AMD PMD WF NFRQ
-LFO:  31  64  64  0    0
-// PAN  FL CON AMS PMS SLOT NE
-CH: 64${[voice.fb, voice.con, voice.ams, voice.pms].map(pad4).join("")}  127  0
-//   AR D1R D2R  RR D1L  TL  KS MUL DT1 DT2 AMS-EN
-M1:${convertSlot(voice.slots[0])}   0   ${pad4(voice.slots[0].am)}
-C1:${convertSlot(voice.slots[1])}   0   ${pad4(voice.slots[0].am)}
-M2:${convertSlot(voice.slots[2])}   0   ${pad4(voice.slots[0].am)}
-C2:${convertSlot(voice.slots[3])}   0   ${pad4(voice.slots[0].am)}
-`;
-}
-
 export function writeOpmVoiceData(filename: string, voices: { opnVoice: OPNVoice; channels: Set<number> }[]) {
   let opmOutput = "";
   opmOutput += OPM_HEADER;
 
   voices.forEach((voice, index) => {
-    opmOutput += "\n" + toVOPM(voice.opnVoice, index, Array.from(voice.channels).join(","));
+    opmOutput +=
+      "\n" + voice.opnVoice.toOPM().toFile("opm", { number: index, name: `CH${Array.from(voice.channels).join(",")}` });
   });
 
   fs.writeFileSync(filename, opmOutput);

--- a/src/opm.ts
+++ b/src/opm.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import { OPNVoice, OPNSlotParam } from "ym-voice";
+
+const OPM_HEADER = "//VOPM tone data\n//Ripped by vgm-conv\n\n";
+
+function pad4(value: number) {
+  return `${value}`.padStart(4, " ");
+}
+
+function toVOPM(voice: OPNVoice, id: number = 0, channels: string = "") {
+  function convertSlot(slot: OPNSlotParam) {
+    return [slot.ar, slot.dr, slot.sr, slot.rr, slot.sl, slot.tl, slot.ks, slot.ml, slot.dt].map(pad4).join("");
+  }
+  return `@:${id} CH${channels}
+//  LFRQ AMD PMD WF NFRQ
+LFO:  31  64  64  0    0
+// PAN  FL CON AMS PMS SLOT NE
+CH: 64${[voice.fb, voice.con, voice.ams, voice.pms].map(pad4).join("")}  127  0
+//   AR D1R D2R  RR D1L  TL  KS MUL DT1 DT2 AMS-EN
+M1:${convertSlot(voice.slots[0])}   0   ${pad4(voice.slots[0].am)}
+C1:${convertSlot(voice.slots[1])}   0   ${pad4(voice.slots[0].am)}
+M2:${convertSlot(voice.slots[2])}   0   ${pad4(voice.slots[0].am)}
+C2:${convertSlot(voice.slots[3])}   0   ${pad4(voice.slots[0].am)}
+
+`;
+}
+
+export function writeOpmVoiceData(filename: string, voices: { opnVoice: OPNVoice; channels: Set<number> }[]) {
+  let opmOutput = "";
+  opmOutput += OPM_HEADER;
+
+  voices.forEach((voice, index) => {
+    opmOutput += toVOPM(voice.opnVoice, index, Array.from(voice.channels).join(","));
+  });
+
+  fs.writeFileSync(filename, opmOutput);
+}


### PR DESCRIPTION
I have modified `OPNToYM2413Converter` to optionally log a `.opm` voice file for VOPM for a given VGM file. `OPNToYM2413Converter` already does most of the work to compile and normalize voices, so this is a pretty trivial change.

If this change seems reasonable, I can move the new contents of the `opm.ts` file into [`ym-voice`](https://github.com/digital-sound-antiques/ym-voice) instead, since that seems like a more appropriate separation of concerns. This code works for my needs as-is, though, so I want to get some confirmation that this feature is acceptable before going through those upstream changes.

Another note: some OPM values are hard-coded, because they are not represented in `OPNVoice`.

An example `.opm` file I generated from running
```bash
vgm-conv -f ym2203 -t ym2413 -o test.vgz ./01\ Feena.vgz -D opmOutput='voicetest.opm'
```
```
//VOPM tone data
//Ripped by vgm-conv

@:0 CH0,1,2
//  LFRQ AMD PMD WF NFRQ
LFO:  31  64  64  0    0
// PAN  FL CON AMS PMS SLOT NE
CH: 64   0   4   0   0  127  0
//   AR D1R D2R  RR D1L  TL  KS MUL DT1 DT2 AMS-EN
M1:  18   0   0   6   0  35   0   2   6   0      0
C1:  18   0   0   6   0   0   0   2   5   0      0
M2:  18   0   0   6   0  35   0   2   1   0      0
C2:  18   0   0   6   0   0   0   2   0   0      0

@:1 CH2
//  LFRQ AMD PMD WF NFRQ
LFO:  31  64  64  0    0
// PAN  FL CON AMS PMS SLOT NE
CH: 64   7   4   0   0  127  0
//   AR D1R D2R  RR D1L  TL  KS MUL DT1 DT2 AMS-EN
M1:  31   2   2   0   0  33   2   2   6   0      0
C1:  22   2   3   4   2   0   1   2   5   0      0
M2:  31   2   2   0   0  13   1   1   2   0      0
C2:  22   2   3   4   2   0   1   2   1   0      0

@:2 CH0,1
//  LFRQ AMD PMD WF NFRQ
LFO:  31  64  64  0    0
// PAN  FL CON AMS PMS SLOT NE
CH: 64   7   4   0   0  127  0
//   AR D1R D2R  RR D1L  TL  KS MUL DT1 DT2 AMS-EN
M1:  31   0   8   0   4  32   3   1   2   0      0
C1:  25   7   7   7   3   0   2   1   4   0      0
M2:  31   0   8   0   4  28   3   3   5   0      0
C2:  25   8   6   7   3   0   2   1   1   0      0

@:3 CH0,1,2
//  LFRQ AMD PMD WF NFRQ
LFO:  31  64  64  0    0
// PAN  FL CON AMS PMS SLOT NE
CH: 64   7   2   0   0  127  0
//   AR D1R D2R  RR D1L  TL  KS MUL DT1 DT2 AMS-EN
M1:  25  10   0   5   1  29   1   1   4   0      0
C1:  25  11   0   8   5  15   1   5   4   0      0
M2:  28  13   0   6   2  48   1   1   3   0      0
C2:  14   4   0   6   0   0   1   1   4   0      0
```