### PR TITLE
Fix normalize total level for algorithm 7 using AR

### DIFF
--- a/src/converter/opn-to-ym2413-converter.ts
+++ b/src/converter/opn-to-ym2413-converter.ts
@@ -64,11 +64,11 @@ function _normalizeTotalLevel(data: number[]): number[] {
       data[7] -= min;
       break;
     case 7:
-      min = Math.min(data[5], data[6], data[7], data[8]);
+      min = Math.min(data[4], data[5], data[6], data[7]);
+      data[4] -= min;
       data[5] -= min;
       data[6] -= min;
       data[7] -= min;
-      data[8] -= min;
       break;
   }
   return data;


### PR DESCRIPTION
Operator 0's total level should be `d[4]` in the patch, not `d[8]` (see [`opn-voice.ts`](https://github.com/digital-sound-antiques/ym-voice/blob/1ce2363f1f3173b73913fb478804e55304e4deff/src/opn-voice.ts#L157)), just a simple off-by-one / zero-indexing error. Not a super big issue because algorithm 7 is not often used.